### PR TITLE
Adding terminfo developer lib installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN set -e;\
     git \
     gzip \
     libpq-dev \
+    libtinfo-dev \
     postgresql \
     postgresql-client \
     python \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build publish
 
 IMAGE_NAME=blockmason/lndr-circleci
-IMAGE_VERSION=1.0.0.0
+IMAGE_VERSION=1.0.1
 IMAGE_TAG=${IMAGE_NAME}:${IMAGE_VERSION}
 
 build:


### PR DESCRIPTION
- installing the debian package `libtinfo-dev` which is now required by `hs-web3`
   + a very silly dep, I might try to remove it from the culprit haskell library
- updating image version 1.0.0.0 -> 1.0.1 (using semver from here on out)
